### PR TITLE
FIX:

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1154,7 +1154,7 @@ class ExtraFields
 				list($val, $parent) = explode('|', $val);
 				$out.='<option value="'.$key.'"';
 				$out.= (((string) $value == (string) $key)?' selected':'');
-				$out.= (!empty($parent)?' parent="'.$parent.'"':'');
+				$out.= (!empty($parent)?' data-parent="'.$parent.'"':'');
 				$out.='>';
 				if ($langfile && $val) $out.=$langs->trans($val);
 				else $out.=$val;
@@ -1310,7 +1310,7 @@ class ExtraFields
 
                                 $out .= '<option value="' . $obj->rowid . '"';
                                 $out .= ($value == $obj->rowid ? ' selected' : '');
-                                $out .= (!empty($parent) ? ' parent="' . $parent . '"' : '');
+                                $out .= (!empty($parent) ? ' data-parent="' . $parent . '"' : '');
                                 $out .= '>' . $labeltoshow . '</option>';
                             }
 

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6333,7 +6333,8 @@ class Form
 				{
 					if (sizeof(explode("|", $value)) == 2){
 						$info = explode("|", $value);
-						$out.= '<option value="'.$key.'" parent="'.$info[1].'"';
+						$out.= '<option value="'.$key.'" data-parent="'.$info[1].'"';
+						$value = $info[0];
 					} else {
 						$out .= '<option value="' . $key . '"';
 					}
@@ -6342,7 +6343,7 @@ class Form
 						$out.= ' selected';
 					}
 					$out.= '>';
-					$newval = ($translate ? $langs->trans($info[0]) : $info[0]);
+					$newval = ($translate ? $langs->trans($value) : $value);
 					$newval = ($key_in_label ? $key.' - '.$newval : $newval);
 					$out.= dol_htmlentitiesbr($newval);
 					$out.= '</option>'."\n";


### PR DESCRIPTION
## FIX:

- position of select2 options not always next to the select element → rebuild the list of options dynamically
- use of non-standard HTML attribute "parent" → replaced with "data-parent"
- options of normal multiselects (with no dependency management) had empty label
- when one multiselect needed to be hidden, all multiselects were hidden
- deduplication of some jQuery selectors
- 
## REMAINS TO DO:

- put js code in a separate js file
- use the same js in extrafields.tpl.php (it has the same js, but I didn't fix it there)